### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.3.2'
     compile 'commons-io:commons-io:2.4'
     compile 'commons-validator:commons-validator:1.4.0'
-    compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-collections:commons-collections:3.2.2'
     compile 'org.swinglabs:swing-layout:1.0.3'
     compile 'org.swinglabs:swingx:1.6.1'
     compile 'com.typesafe:config:1.3.0'


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
